### PR TITLE
Allow any version of 0.8.x of solidity to import these contracts

### DIFF
--- a/contracts/IEditionSingleMintable.sol
+++ b/contracts/IEditionSingleMintable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.6;
+pragma solidity ^0.8.6;
 
 interface IEditionSingleMintable {
   function mintEdition(address to) external returns (uint256);

--- a/contracts/IPublicSharedMetadata.sol
+++ b/contracts/IPublicSharedMetadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.6;
+pragma solidity ^0.8.6;
 
 /// Shared public library for on-chain NFT functions
 interface IPublicSharedMetadata {

--- a/contracts/SharedNFTLogic.sol
+++ b/contracts/SharedNFTLogic.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity 0.8.6;
+pragma solidity ^0.8.6;
 
 import {StringsUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 import {Base64} from "base64-sol/base64.sol";

--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -10,7 +10,7 @@
 
  */
 
-pragma solidity 0.8.6;
+pragma solidity ^0.8.6;
 
 import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import {IERC2981Upgradeable, IERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";

--- a/contracts/SingleEditionMintableCreator.sol
+++ b/contracts/SingleEditionMintableCreator.sol
@@ -10,7 +10,7 @@
 
  */
 
-pragma solidity 0.8.6;
+pragma solidity ^0.8.6;
 
 import {ClonesUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
 import {CountersUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";


### PR DESCRIPTION
* Allows for easier integrations with other contracts
* No need to specifically require `0.8.6` vs `0.8.9` etc.