### PR TITLE
add IEditionSingleMintable interface id check

### DIFF
--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -335,6 +335,7 @@ contract SingleEditionMintable is
         returns (bool)
     {
         return
+            type(IEditionSingleMintable).interfaceId == interfaceId ||
             type(IERC2981Upgradeable).interfaceId == interfaceId ||
             ERC721Upgradeable.supportsInterface(interfaceId);
     }


### PR DESCRIPTION
Adds check for the specific zora nft-editions interface to `supportsInterface` function.
Useful when creating a sales smart contract specifically for zora's NFT editions.

`type(IEditionSingleMintable).interfaceId == 0x2fc51e5a`

