### PR TITLE
Fix implementation re-initialization issue

### DIFF
--- a/contracts/SingleEditionMintable.sol
+++ b/contracts/SingleEditionMintable.sol
@@ -69,6 +69,8 @@ contract SingleEditionMintable is
     // Global constructor for factory
     constructor(SharedNFTLogic _sharedNFTLogic) {
         sharedNFTLogic = _sharedNFTLogic;
+
+        _disableInitializers();
     }
 
     /**
@@ -137,7 +139,7 @@ contract SingleEditionMintable is
     }
 
     /**
-      @param _salePrice if sale price is 0 sale is stopped, otherwise that amount 
+      @param _salePrice if sale price is 0 sale is stopped, otherwise that amount
                        of ETH is needed to start the sale.
       @dev This sets a simple ETH sales price
            Setting a sales price allows users to mint the edition until it sells out.
@@ -243,7 +245,7 @@ contract SingleEditionMintable is
 
     /**
         @param tokenId Token ID to burn
-        User burn function for token id 
+        User burn function for token id
      */
     function burn(uint256 tokenId) public {
         require(_isApprovedOrOwner(_msgSender(), tokenId), "Not approved");

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "dotenv": "^10.0.0"
   },
   "dependencies": {
-    "ethers": "^5.4.1",
-    "@openzeppelin/contracts-upgradeable": "^4.3.2",
-    "base64-sol": "^1.0.1"
+    "@openzeppelin/contracts-upgradeable": "^4.7.3",
+    "base64-sol": "^1.0.1",
+    "ethers": "^5.4.1"
   }
 }

--- a/test/SingleEditionMintableTest.ts
+++ b/test/SingleEditionMintableTest.ts
@@ -13,22 +13,42 @@ describe("SingleEditionMintable", () => {
   let signer: SignerWithAddress;
   let signerAddress: string;
   let dynamicSketch: SingleEditionMintableCreator;
+  let editionImpl: SingleEditionMintable;
 
   beforeEach(async () => {
-    const { SingleEditionMintableCreator } = await deployments.fixture([
+    const { SingleEditionMintableCreator, SingleEditionMintable } = await deployments.fixture([
       "SingleEditionMintableCreator",
       "SingleEditionMintable",
     ]);
-    const dynamicMintableAddress = (
-      await deployments.get("SingleEditionMintable")
-    ).address;
     dynamicSketch = (await ethers.getContractAt(
       "SingleEditionMintableCreator",
       SingleEditionMintableCreator.address
     )) as SingleEditionMintableCreator;
 
+    editionImpl = (await ethers.getContractAt(
+      "SingleEditionMintable",
+      SingleEditionMintable.address
+    )) as SingleEditionMintable;
+
     signer = (await ethers.getSigners())[0];
     signerAddress = await signer.getAddress();
+  });
+
+  it("does not allow re-initialization of the implementation contract", async () => {
+    await expect(
+      editionImpl.initialize(
+        signerAddress,
+        "test name",
+        "SYM",
+        "description",
+        "animation",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "uri",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        12,
+        12
+      )
+    ).to.be.revertedWith("Initializable: contract is already initialized");
   });
 
   it("makes a new edition", async () => {
@@ -294,7 +314,7 @@ describe("SingleEditionMintable", () => {
           200,
           200
         );
-    
+
         const editionResult = await dynamicSketch.getEditionAtId(1);
         const minterContractNew = (await ethers.getContractAt(
           "SingleEditionMintable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,10 +521,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts-upgradeable@^4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.3.2.tgz#92df481362e366c388fc02133cf793029c744cea"
-  integrity sha512-i/pOaOtcqDk4UqsrOv735uYyTbn6dvfiuVu5hstsgV6c4ZKUtu88/31zT2BzkCg+3JfcwOfgg2TtRKVKKZIGkQ==
+"@openzeppelin/contracts-upgradeable@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz#f1d606e2827d409053f3e908ba4eb8adb1dd6995"
+  integrity sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
It bugs me that the implementation contracts can be left uninitialized (and so can become owned by anyone), so let's follow [best practices](https://docs.openzeppelin.com/contracts/4.x/api/proxy#Initializable-_disableInitializers--) and prevent that